### PR TITLE
Rotate keys on incoming tx

### DIFF
--- a/multisigcore/hierarchy.py
+++ b/multisigcore/hierarchy.py
@@ -402,6 +402,24 @@ class Account(object):
         """
         return None
 
+    def rotate_addresses(self, tx):
+        """
+        Rotate receiving and change addresses if a transaction sent coins to them.
+        :type tx: Tx
+        :return: whether any addresses were rotated due to incoming coins
+        :rtype: bool
+        """
+        scripts = [o.script for o in tx.txs_out]
+        rotated = False
+        while standard_tx_out_script(self.current_address()) in scripts:
+            self.next_address()
+            rotated = True
+
+        while standard_tx_out_script(self.current_change_address()) in scripts:
+            self.next_change_address()
+            rotated = True
+        return rotated
+
 
 class SimpleAccount(Account):
     __slots__ = ['_key']

--- a/multisigcore/oracle.py
+++ b/multisigcore/oracle.py
@@ -140,7 +140,7 @@ class Oracle(object):
 
     def _create_oracle_request(self, input_chain_paths, output_chain_paths, spend_id, tx, verifications=None):
         """:nodoc:"""
-        tx = deepcopy(tx)  # keep original Tx object intact
+        tx = deepcopy(tx)  # keep original Tx object intact, so that it is not mutated by fix_input_scripts below.
         # Have the Oracle sign the tx
         chain_paths = []
         input_scripts = []

--- a/multisigcore/test/test_hierarchy.py
+++ b/multisigcore/test/test_hierarchy.py
@@ -219,3 +219,18 @@ class HierarchyTest(TestCase):
         account1 = SimpleAccount(account_key, cache=account.cache)
         self.assertEqual("181yMj2Es6RNvoHgj6bX82r2Vm38rmHV8C", account1.current_address())
         self.assertEqual("1AdEBCFQJHBzHKgWX517rQWCWwQ6qvYfAB", account1.current_change_address())
+
+    def test_rotate_address(self):
+        account_key = self.master_key.account_for_path("0H/1/2H")
+        account = SimpleAccount(account_key)
+        first = "1r1msgrPfqCMRAhg23cPBD9ZXH1UQ6jec"
+        first_change = "19Fi5VpcosH3CtCFjd5HyveM5c4Kecirza"
+        self.assertEqual(first, account.current_address())
+        self.assertEqual(first_change, account.current_change_address())
+        tx = Tx(DEFAULT_VERSION, [], [TxOut(1, standard_tx_out_script("3FfiLhj1yXkXRFRRb9CMsMXBNZXQEv23Pi"))])
+        account.rotate_addresses(tx)
+        self.assertEqual("1r1msgrPfqCMRAhg23cPBD9ZXH1UQ6jec", account.current_address())
+        tx = Tx(DEFAULT_VERSION, [], [TxOut(1, standard_tx_out_script(first)), TxOut(33, standard_tx_out_script(first_change))])
+        self.assertTrue(account.rotate_addresses(tx))
+        self.assertNotEqual(first, account.current_address())
+        self.assertNotEqual(first_change, account.current_change_address())


### PR DESCRIPTION
API for rotating keys when supplied an incoming tx that might spend to the current addresses.