### PR TITLE
Remove pycoin P2SH workarounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ dist
 build
 *.swp
 *.hex
+out
+.ipynb_checkpoints
+.eggs
+scratch.*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ python:
 install: "echo done"
 # command to run tests
 script:
+  - git clone https://github.com/devrandom/pycoin
+  - (cd pycoin && ./setup.py install)
   - ./setup.py install
   - ./setup.py test

--- a/multisigcore/__init__.py
+++ b/multisigcore/__init__.py
@@ -30,7 +30,7 @@ class LazySecretExponentDBWithNetwork(LazySecretExponentDB):
         return None
 
 
-def local_sign(tx, scripts, keys):
+def local_sign(tx, redeem_scripts, keys):
     """
     Utility for locally signing a multisig transaction
 
@@ -40,12 +40,9 @@ def local_sign(tx, scripts, keys):
     :return:
     """
     lookup = None
-    if scripts:
-        raw_scripts = [script.script() for script in scripts]
+    if redeem_scripts:
+        raw_scripts = [script.script() for script in redeem_scripts]
         lookup = build_p2sh_lookup(raw_scripts)
-        # FIXME hack to work around broken p2sh signing in pycoin
-        for i in range(len(tx.unspents)):
-            tx.unspents[i].script = raw_scripts[i]
     if keys:
         netcode = keys[0]._netcode
     else:

--- a/multisigcore/oracle.py
+++ b/multisigcore/oracle.py
@@ -1,15 +1,14 @@
 from __future__ import print_function
-import json
 import uuid
+from copy import deepcopy
 
 import dateutil.tz
 import dateutil.parser
 import requests
-from copy import deepcopy
 
 from pycoin.tx import Tx
 from pycoin.ecdsa import generator_secp256k1
-from pycoin.serialize import b2h, stream_to_bytes
+from pycoin.serialize import stream_to_bytes
 from .hierarchy import *
 from pycoin.tx.script.tools import *
 from pycoin.tx.script import der
@@ -395,6 +394,4 @@ def fix_input_script(inp, redeem_script):
         if op == dummy:
             op = 'OP_0'
         ops1.append(op)
-    # FIXME hack to add redeem script omitted by pycoin
-    ops1.append(b2h(redeem_script))
     inp.script = compile(' '.join(ops1))


### PR DESCRIPTION
Upstream has better P2SH support, but this still requires a little patch that is applied at https://github.com/devrandom/pycoin for now.